### PR TITLE
feat: add release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+
+
+name: Create Release on Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  release:
+    # Run only when the pull request was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Generate a tag based on current UTC date‑time down to seconds, e.g., v20250504123045
+      - name: Set release tag
+        id: version
+        run: echo "TAG=v$(date -u +'%Y%m%d%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.TAG }}
+          name: Release ${{ steps.version.outputs.TAG }}
+          generate_release_notes: true
+          files: Dictionary/data.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation of a release when a pull request is merged. The workflow generates a timestamp-based tag and creates a GitHub release with release notes and a specific file attached.

### New GitHub Actions Workflow:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR1-R32): Added a workflow named "Create Release on Merge" that triggers on the closure of pull requests. It ensures the workflow runs only if the pull request is merged, generates a UTC timestamp-based tag, and creates a GitHub release with release notes and the `Dictionary/data.json` file attached.