### PR TITLE
Add 'Apple Intelligence' to dictionary

### DIFF
--- a/Dictionary/data_v1.json
+++ b/Dictionary/data_v1.json
@@ -26,6 +26,16 @@
             "mid": 501,
             "date": "2025-05-04",
             "author": "Google Form"
+        },
+        {
+            "word": "Apple Intelligence",
+            "ruby": "あっぷるいんてりじぇんす",
+            "word_weight": -15.0,
+            "lcid": 1288,
+            "rcid": 1288,
+            "mid": 501,
+            "date": "2025-05-04",
+            "author": "Google Form"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds a new dictionary entry to the `Dictionary/data_v1.json` file. The new entry includes the word "Apple Intelligence" along with its corresponding metadata.

Details of the change:

* [`Dictionary/data_v1.json`](diffhunk://#diff-166f5f7dbfa983511661b90edb5da88cbf6ee7323214d00120ba738a67ededbdR29-R38): Added a new dictionary entry for the word "Apple Intelligence," including its pronunciation (`ruby`), `word_weight`, `lcid`, `rcid`, `mid`, `date`, and `author`.