### PR TITLE
Add unittests for validate_json and run them in CI

### DIFF
--- a/.github/workflows/validate-data.yaml
+++ b/.github/workflows/validate-data.yaml
@@ -4,11 +4,13 @@ on:
   pull_request:
 
 jobs:
-  validate-json:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Validate JSON format
-        run: |
-          python scripts/validate_json.py Dictionary/data_v1.json
+    validate-json:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+        - name: Run unit tests
+          run: python -m unittest discover -v
+        - name: Validate JSON format
+          run: |
+            python scripts/validate_json.py Dictionary/data_v1.json

--- a/tests/test_validate_json.py
+++ b/tests/test_validate_json.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+import unittest
+
+# Import validate function from scripts/validate_json.py
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+import validate_json  # type: ignore
+
+
+class ValidateJsonTests(unittest.TestCase):
+    def test_valid_file(self):
+        path = Path("Dictionary/data_v1.json")
+        self.assertTrue(validate_json.validate(path))
+
+    def test_missing_metadata_key(self):
+        data = {
+            "metadata": {"status": "active"},
+            "data": []
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
+            json.dump(data, tmp)
+            tmp_path = Path(tmp.name)
+        try:
+            self.assertFalse(validate_json.validate(tmp_path))
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_entry_key(self):
+        metadata = {
+            "status": "active",
+            "name": "tmp.json",
+            "description": "temp",
+            "version": "1.0",
+            "last_update": "2025-01-01T00:00:00"
+        }
+        data = {
+            "metadata": metadata,
+            "data": [
+                {"word": "test"}
+            ]
+        }
+        with tempfile.NamedTemporaryFile("w", delete=False, suffix=".json") as tmp:
+            json.dump(data, tmp)
+            tmp_path = Path(tmp.name)
+        try:
+            self.assertFalse(validate_json.validate(tmp_path))
+        finally:
+            tmp_path.unlink()
+
+    def test_cli_valid_exit_code(self):
+        path = Path("Dictionary/data_v1.json")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "validate_json.py"), str(path)],
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for the `validate_json.validate` function and CLI
- run the new unit tests in the CI workflow

## Testing
- `python -m unittest discover -v`