### PR TITLE
Improve issue title generation from Google Form

### DIFF
--- a/.github/workflows/google_form.yaml
+++ b/.github/workflows/google_form.yaml
@@ -19,7 +19,15 @@ jobs:
         with:
           script: |
             const payload = context.payload.client_payload;
-            const title = `Form response – ${payload.filename}`;
+            // Extract the word after "単語を入力してください:" if present
+            const wordMatch = payload.content.match(/^単語を入力してください:\s*(.+)$/m);
+            const word = wordMatch ? wordMatch[1].trim() : null;
+
+            const titlePrefix = word
+              ? `vocabulary: add 「${word}」`
+              : 'Form response';
+            const title = `${titlePrefix} (${payload.filename})`;
+
             const body = [
               'Google Formに辞書追加のリクエストがありました。対応を検討してください。',
               '',


### PR DESCRIPTION
## Summary
- parse the word after `単語を入力してください:` from Google Form content
- build the issue title using the parsed word

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c050faa648330bf69e9c704dbe08f