### PR TITLE
feat: filter Google Form notes with GitHub Models

### DIFF
--- a/.github/workflows/google_form.yaml
+++ b/.github/workflows/google_form.yaml
@@ -9,6 +9,7 @@ on:
 permissions:
   issues: write
   contents: read
+  models: read
 
 jobs:
   create-issue:
@@ -16,12 +17,67 @@ jobs:
     steps:
       - name: Open issue with form response
         uses: actions/github-script@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
             const payload = context.payload.client_payload;
+            const content = payload.content;
             // Extract the word after "単語を入力してください:" if present
-            const wordMatch = payload.content.match(/^単語を入力してください:\s*(.+)$/m);
+            const wordMatch = content.match(/^単語を入力してください:\s*(.+)$/m);
             const word = wordMatch ? wordMatch[1].trim() : null;
+
+            // Extract supplementary info
+            const supplementMatch = content.match(/^この単語について補足すべき情報があれば記載してください:\s*(.*)$/m);
+            const supplement = supplementMatch ? supplementMatch[1].trim() : '';
+
+            let filteredContent = content;
+            if (supplement) {
+              try {
+                const res = await fetch('https://models.github.ai/inference/chat/completions', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+                  },
+                  body: JSON.stringify({
+                    model: 'openai/gpt-4o',
+                    messages: [
+                      {
+                        role: 'system',
+                        content: 'You check whether the user text is toxic. If toxic, rewrite it into Japanese cat-speak. Respond in JSON.'
+                      },
+                      { role: 'user', content: supplement }
+                    ],
+                    response_format: {
+                      type: 'json_schema',
+                      json_schema: {
+                        name: 'toxicity',
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            toxic: { type: 'boolean' },
+                            cat: { type: 'string' }
+                          },
+                          required: ['toxic', 'cat'],
+                          additionalProperties: false
+                        }
+                      }
+                    }
+                  })
+                });
+                if (res.ok) {
+                  const data = await res.json();
+                  const msg = data?.choices?.[0]?.message?.content;
+                  const result = JSON.parse(msg);
+                  if (result.toxic) {
+                    filteredContent = content.replace(/^この単語について補足すべき情報があれば記載してください:\s*(.*)$/m, `この単語について補足すべき情報があれば記載してください: ${result.cat}`);
+                  }
+                }
+              } catch (err) {
+                core.warning(`LLM filtering failed: ${err}`);
+              }
+            }
 
             const titlePrefix = word
               ? `vocabulary: add 「${word}」`
@@ -32,7 +88,7 @@ jobs:
               'Google Formに辞書追加のリクエストがありました。対応を検討してください。',
               '',
               '```',
-              payload.content,
+              filteredContent,
               '```'
             ].join('\n');
             await github.rest.issues.create({


### PR DESCRIPTION
## Summary
- detect and rewrite toxic Google Form supplemental notes using GitHub Models
- add `models: read` permission and fetch GPT-4o for cat-speak translation when needed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c27957cc8330b32df91d2c6bd2d6