### PR TITLE
fix: checkout repo before running form script

### DIFF
--- a/.github/workflows/google_form.yaml
+++ b/.github/workflows/google_form.yaml
@@ -15,6 +15,8 @@ jobs:
   create-issue:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
       - name: Open issue with form response
         uses: actions/github-script@v7
         env:


### PR DESCRIPTION
## Summary
- checkout repository so google form workflow can access scripts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5cce21ad88330be14539bd5fcbbc3