### PR TITLE
Fix release workflow permissions and checkout ref

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,11 @@
 name: Create Release on Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -17,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       # Generate a tag based on current UTC date‑time down to seconds, e.g., v20250504123045
       - name: Set release tag


### PR DESCRIPTION
## Summary
- Change release workflow trigger to pull_request_target for merged PR handling
- Add workflow-level contents: write permission
- Checkout the merge commit SHA to ensure release runs against merged state
 
## Why

Prevent GitHub Release creation failures (403) on auto release workflow.